### PR TITLE
PR-37864: upgrade drop-ins, android to 6.16.0 and iOS to 5.23.0

### DIFF
--- a/RNBraintreeDropIn.podspec
+++ b/RNBraintreeDropIn.podspec
@@ -14,9 +14,9 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
   s.dependency    'React'
-  s.dependency    'Braintree', '5.23.0'
-  s.dependency    'BraintreeDropIn', '9.11.0'
-  s.dependency    'Braintree/DataCollector', '5.23.0'
-  s.dependency    'Braintree/ApplePay', '5.23.0'
-  s.dependency    'Braintree/Venmo', '5.23.0'
+  s.dependency    'Braintree', '5.26.0'
+  s.dependency    'BraintreeDropIn', '9.13.0'
+  s.dependency    'Braintree/DataCollector', '5.26.0'
+  s.dependency    'Braintree/ApplePay', '5.26.0'
+  s.dependency    'Braintree/Venmo', '5.26.0'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.braintreepayments.api:drop-in:6.14.0'
+    implementation 'com.braintreepayments.api:drop-in:6.16.0'
     implementation 'com.facebook.react:react-native:+'
 }
 


### PR DESCRIPTION
I have followed the same approach as in previous times:
- Android: https://github.com/spotahome/react-native-braintree-dropin-ui-fork/commit/21e9983adcf77faeeb842c6be896fe5ebb9f38b2
- iOS: https://github.com/spotahome/react-native-braintree-dropin-ui-fork/commit/e1a732cc46a8fe78b05d22fefb461d67cef7ffef